### PR TITLE
feat: Add GoDaily button to ainsleyclark.com hero section

### DIFF
--- a/sites/ainsley-clark/layouts/index.html
+++ b/sites/ainsley-clark/layouts/index.html
@@ -40,6 +40,12 @@
 								"text" "Visit ainsley.dev"
 								"title" "Scroll down to explore"
 							)}}
+							{{ partial "components/button.html" (dict
+								"colour" "black"
+								"link" "https://godaily.dev"
+								"text" "Visit GoDaily"
+								"title" "Visit GoDaily - A daily newsletter for Go developers"
+							)}}
 						</div>
 					</div><!-- /Hero Animation -->
 				</div><!-- /Col -->

--- a/themes/shared/assets/scss/layout/_hero.scss
+++ b/themes/shared/assets/scss/layout/_hero.scss
@@ -194,6 +194,7 @@
 
 	&-buttons {
 		display: flex;
+		flex-wrap: wrap;
 		gap: 14px;
 	}
 


### PR DESCRIPTION
Adds a third "Visit GoDaily" CTA button to the hero linking to
https://godaily.dev, and adds flex-wrap to .hero-buttons so all
three buttons wrap correctly on smaller viewports.

https://claude.ai/code/session_01XgBJ1FgoX9hnKCMMYSqevt