### PR TITLE
contenr: Update Ainsley Clark role to JetBrains Go Developer Advocate

### DIFF
--- a/sites/ainsley-clark/config/_default/params.yaml
+++ b/sites/ainsley-clark/config/_default/params.yaml
@@ -16,7 +16,7 @@ person:
     name: Ainsley Clark
     givenName: Ainsley
     familyName: Clark
-    jobTitle: "Designer & Developer"
+    jobTitle: "Go Developer Advocate"
 company:
     name: ainsley.dev LTD
     number: 14550437

--- a/sites/ainsley-clark/content/_index.md
+++ b/sites/ainsley-clark/content/_index.md
@@ -1,8 +1,8 @@
 ---
-title: Full Stack Engineer, Author, Speaker & Mentor
-description: Ainsley Clark, a full stack software engineer working at Just Eat Takeaway.com & founder of ainsley.dev with a passion for all things tech.
+title: Go Developer Advocate, Author, Speaker & Mentor
+description: Ainsley Clark, Go Developer Advocate at JetBrains & founder of ainsley.dev with a passion for all things tech.
 heading: Shipping Go at <span class="type-serif">scale*</span><br/>Growing engineers,<br class="d-none d-tab-inline"/>Building communities that <u>last</u>
-lead: Senior software engineer at Just Eat Takeaway.com, owner of ainsley.dev (web design & dev), conference speaker, mentor and open-source contributor. Passionate about writing well-crafted Go, mentoring the next generation and building communities where engineers thrive.
+lead: Go Developer Advocate at JetBrains, owner of ainsley.dev (web design & dev), conference speaker, mentor and open-source contributor. Passionate about writing well-crafted Go, mentoring the next generation and building communities where engineers thrive.
 styles:
   - scss/pages/home.scss
 bio:
@@ -12,9 +12,9 @@ bio:
     <h3>Hi, I'm Ainsley</h3>
     <p>I've always been a bit of a geek at heart. It all started off with a pair of DJ decks as a kid which led me to a Music Technology degree, and somewhere along the way turned into a career building software. I can truly say that I love what I do and I'm always excited about all things tech.</p>
     <h4>Engineering</h4>
-    <p>Most of my time is spent writing Go at Just Eat Takeaway.com, leading platform architecture across teams and building tools and services that last.</p>
+    <p>Most of my time is spent writing Go as a Developer Advocate at JetBrains, working closely with the community and building tools and services that last.</p>
     <h4>Advocating</h4>
-    <p>Giving back matters to me, whether that's speaking at conferences, contributing to open source or contributing to the Just Eat Go Guild to raise engineering standards across teams.</p>
+    <p>Giving back matters to me, whether that's speaking at conferences, contributing to open source or running Go guilds and meetups to raise engineering standards across teams.</p>
     <h4>Mentoring</h4>
     <p>I've always loved investing in people and watching them grow through one-to-ones, code reviews and working on soft skills to help them thrive in their career.</p>
 skills:

--- a/sites/ainsley-clark/content/_index.md
+++ b/sites/ainsley-clark/content/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Go Developer Advocate, Author, Speaker & Mentor
+title: Full Stack Engineer, Go Developer Advocate, Speaker & Mentor
 description: Ainsley Clark, Go Developer Advocate at JetBrains & founder of ainsley.dev with a passion for all things tech.
 heading: Shipping Go at <span class="type-serif">scale*</span><br/>Growing engineers,<br class="d-none d-tab-inline"/>Building communities that <u>last</u>
 lead: Go Developer Advocate at JetBrains, owner of ainsley.dev (web design & dev), conference speaker, mentor and open-source contributor. Passionate about writing well-crafted Go, mentoring the next generation and building communities where engineers thrive.


### PR DESCRIPTION
Replaces the current-employment references to Just Eat Takeaway.com on the
Ainsley Clark site with the JetBrains Go Developer Advocate role, covering
the page title, meta description, hero lead and bio copy. Also refreshes the
stale Person schema jobTitle from "Designer & Developer".

Historical references are left intact: the 2025 talk abstracts, the JET Tech
Fest entry, the Just Eat testimonial and the logo carousel all describe past
work rather than current employment.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XCfEf9FsMqGfCiABEvUt3F